### PR TITLE
ci: adopt other code coverage tools

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,4 +60,21 @@ jobs:
           go-version-file: go.mod
 
       - name: Run tests
-        run: go test ./...
+        run: go test -covermode=atomic -coverprofile=cov.txt ./...
+
+      - name: Upload coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: cov.txt
+          flags: go
+
+      - name: Upload coverage to Coveralls
+        continue-on-error: true
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          files: cov.txt
+          format: golang
+          flag-name: go

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 A service to visualize and browse your code coverage.
 
+## Alternatives
+
+These tools may be great alternatives to this tool for you.
+I think they're valuable parts of the code quality community, and as such want to make sure they're known.
+I even go so far as to use them for this project, because they are good at what they do for what I need here.
+
+* [CodeCov by Sentry](https://about.codecov.io/)
+* [Coveralls](https://coveralls.io/)
+
 ## Licence
 
 This project is licensed under the BSD 3-Clause Licence.


### PR DESCRIPTION
We should be open to other code coverage tools, in good open source spirit. Likewise, adopt them for this project.