### PR TITLE
ci: split Go linters

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,8 +13,7 @@ on:
 permissions: {}
 
 jobs:
-  lint:
-    name: Lint Go code
+  golangci-lint:
     runs-on: ubuntu-latest
     permissions:
       contents: read # to check out the code
@@ -35,19 +34,51 @@ jobs:
         with:
           version: v2.0
 
+  go-mod:
+    name: go.mod linting
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the code
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version-file: go.mod
+
       - name: go mod tidy
-        if: success() || failure()
         run: |
           if ! go mod tidy -diff; then
             echo "go mod tidy failed. Please run 'just lint' and commit the changes."
             exit 1
           fi
 
+  sqlc-generate:
+    name: sqlc generated code linter
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to check out the code
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
+        with:
+          go-version-file: go.mod
+
       - name: sqlc generate
-        if: success() || failure()
         run: |
           go tool sqlc generate
-          if ! git diff --exit-code pkg/db/{db,models,querier,queries.sql}.go; then
+          if ! git diff --exit-code; then
             echo "sqlc generate failed. Please run 'just generate' and commit the changes."
             exit 1
           fi

--- a/.github/workflows/sqlfluff.yml
+++ b/.github/workflows/sqlfluff.yml
@@ -44,4 +44,3 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           title: SQLFluff lint
           input: annotations.json
-      


### PR DESCRIPTION
The sqlc linter is particularly slow, so splitting them all lets it start earlier.