### PR TITLE
docs: remove openapi-generator-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ When developing, you need:
 * `actionlint` (<https://github.com/rhysd/actionlint>)
 * `goimports` (<https://pkg.go.dev/golang.org/x/tools/cmd/goimports>)
 * `docker` & `docker compose` (<https://docs.docker.com/engine/install/>, must be accessible sudo-less; [Podman](https://podman.io/docs/installation) probably also works if aliased to `docker`)
-* `openapi-generator-cli` (<https://github.com/OpenAPITools/openapi-generator>)
 
 You may want to run `just setup-precommit` to have some fast linters running on every commit.
 


### PR DESCRIPTION
We use oapi-codegen now instead, which is a `go tool` binary.